### PR TITLE
Small fixes

### DIFF
--- a/include/teobase/logging.h
+++ b/include/teobase/logging.h
@@ -11,7 +11,7 @@ extern "C" {
 #endif
 
 /**
- * Message importance/verbocity type. Passed unmodified to output function.
+ * Message importance/verbosity type. Passed unmodified to output function.
  * Default loggers always output all messages of types (ERROR, IMPORTANT, INFO)
  * Debug builds additionally allows DEBUG messages.
  * All types CUSTOM and above are skipped by default

--- a/src/teobase/time.c
+++ b/src/teobase/time.c
@@ -22,7 +22,7 @@ int64_t teotimeGetCurrentTimeUs() {
 
     _ftime64_s(&time_value);
 
-    current_time_us = time_value.time * MICROSECONDS_IN_SECOND + time_value.millitm * MICROSECONDS_IN_MILLISECOND;
+    current_time_us = time_value.time * MICROSECONDS_IN_SECOND + (int64_t)time_value.millitm * MICROSECONDS_IN_MILLISECOND;
 #else
     struct timeval time_value;
     memset(&time_value, 0, sizeof(time_value));


### PR DESCRIPTION
Fixes in logging and time function.
* Fixed integer variable overflow in teotimeGetCurrentTimeUs on Windows.
* Fixed possible null function variable invocation in logging.
* Fixed typo in comment.